### PR TITLE
Add new runner syntaxes.

### DIFF
--- a/src/firefoxprofilerunner.cpp
+++ b/src/firefoxprofilerunner.cpp
@@ -59,16 +59,27 @@ void FirefoxRunner::reloadPluginConfiguration(const QString &configFile) {
     }
 
     QList<Plasma::RunnerSyntax> syntaxes;
-    syntaxes.append(Plasma::RunnerSyntax("firefox :q?",
-                                         "Plugin gets triggered by firef... after that you can search the profiles by name")
-    );
-    syntaxes.append(Plasma::RunnerSyntax("firefox :q -p", "Launch profile in private window"));
+    syntaxes.append(Plasma::RunnerSyntax(
+            "firefox :q:",
+            "Plugin gets triggered by fire... after that you can search the profiles by name"
+    ));
+    syntaxes.append(Plasma::RunnerSyntax("firefox -p :q:", "Launch profile in private window"));
+    syntaxes.append(Plasma::RunnerSyntax("firefox :q: -p", "Launch profile in private window"));
+    syntaxes.append(Plasma::RunnerSyntax(
+            "ff :q:",
+            "Plugin gets triggered by ff... after that you can search the profiles by name"
+    ));
+    syntaxes.append(Plasma::RunnerSyntax("ff -p :q:", "Launch profile in private window"));
+    syntaxes.append(Plasma::RunnerSyntax("ff :q: -p", "Launch profile in private window"));
     setSyntaxes(syntaxes);
 }
 
 void FirefoxRunner::match(Plasma::RunnerContext &context) {
     QString term = context.query();
-    if (!context.isValid() || !term.startsWith(prefix)) {
+    if (!context.isValid()) {
+        return;
+    }
+    if (!term.startsWith(shortPrefix, Qt::CaseInsensitive) && !term.startsWith(mediumPrefix, Qt::CaseInsensitive)) {
         return;
     }
 

--- a/src/firefoxprofilerunner.h
+++ b/src/firefoxprofilerunner.h
@@ -13,11 +13,20 @@ Q_OBJECT
 public:
     FirefoxRunner(QObject *parent, const QVariantList &args);
 
-    QLatin1String prefix = QLatin1String("fire");
+    // NOTE: Prefixes need to be included in filterRegex.
+    QLatin1String shortPrefix = QLatin1String("ff");
+    QLatin1String mediumPrefix = QLatin1String("fire");
+    QRegularExpression filterRegex = QRegularExpression(
+            R"(^(?:ff|fire\w*)(?: (.+))$)",
+            QRegularExpression::CaseInsensitiveOption
+    );
+    const QRegularExpression privateWindowFlagRegex = QRegularExpression(
+            R"((\s+-p\b))",
+            QRegularExpression::CaseInsensitiveOption
+    );
+
     QFileSystemWatcher watcher;
     QString launchCommand;
-    QRegularExpression filterRegex = QRegularExpression(R"(^fire\w*(?: (.+))$)");
-    const QRegularExpression privateWindowFlagRegex = QRegularExpression(" -p *$");
     QList<Profile> profiles;
     bool hideDefaultProfile, showAlwaysPrivateWindows, proxychainsIntegrated, proxychainsForceNewInstance;
     QIcon firefoxIcon;


### PR DESCRIPTION
Adds new `ff` prefix, case insensitive syntax and allows `-p` at the end. For running an "Example" profile, you can now use:

```
fire -p Example
fire example -p
FIRE EXAMPLE -P
ff example
ff e -p
```